### PR TITLE
add exception to dns resolving: if resolving fails set status to false

### DIFF
--- a/netgwm.py
+++ b/netgwm.py
@@ -134,24 +134,29 @@ class GatewayManager:
 
         if ipresult is True:
             for site in check_sites:
-                site_ip = socket.gethostbyname(site)
+                try:
+                    site_ip = socket.gethostbyname(site)
     
-                os.system('/sbin/ip rule add iif lo to %s lookup netgwm_check' % site_ip)
+                    os.system('/sbin/ip rule add iif lo to %s lookup netgwm_check' % site_ip)
     
-                p       = os.popen('ping -q -n -W 1 -c 2 %s 2> /dev/null' % site_ip)
-                pingout = p.read()
-                status  = not p.close()
+                    p       = os.popen('ping -q -n -W 1 -c 2 %s 2> /dev/null' % site_ip)
+                    pingout = p.read()
+                    status  = not p.close()
     
-                os.system('/sbin/ip rule del iif lo to %s lookup netgwm_check' % site_ip)
+                    os.system('/sbin/ip rule del iif lo to %s lookup netgwm_check' % site_ip)
     
-                if status is True:
-                    # ping success
-                    rtt  = re.search('\d+\.\d+/(\d+\.\d+)/\d+\.\d+/\d+\.\d+', pingout).group(1)
-                    info = 'up:'+site+':'+rtt
-                    break
-                else:
-                    # ping fail
-                    info = 'down'
+                    if status is True:
+                        # ping success
+                        rtt  = re.search('\d+\.\d+/(\d+\.\d+)/\d+\.\d+/\d+\.\d+', pingout).group(1)
+                        info = 'up:'+site+':'+rtt
+                        break
+                    else:
+                        # ping fail
+                        info = 'down'
+
+                except:
+                    status = False
+            
             os.system('/sbin/ip route del default %s table netgwm_check' % self.generate_route())
         else:
             status = False


### PR DESCRIPTION
When dns resolving don't work for any reason, this construction:
site_ip = socket.gethostbyname(site) 
Causes error and execution stop, it leads to failures because in this case gateway will not be switched - execution will stop earlier.
