### PR TITLE
add post-replace hook dropping all udp streams

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,6 @@ Homepage: http://www.flant.ru
 
 Package: netgwm
 Architecture: all
-Depends: ${misc:Depends}, python-yaml, python-minimal
+Depends: ${misc:Depends}, python-yaml, python-minimal, conntrack
 Description: change uplink
  monitor uplink and change gateway

--- a/samples/post-replace.d/conntrack.sh
+++ b/samples/post-replace.d/conntrack.sh
@@ -1,0 +1,18 @@
+#!/bin/sh 
+
+# Warning! This script should be placed in the
+# /etc/netgwm/post-replace.d/ directory to work.
+#
+# All the scripts placed in post-replace.d are
+# executed every time NetGWM changes the current
+# network gateway. In these scripts, you can use
+# the following arguments:
+#
+# $1 - new gateway identifier
+# $2 - new gateway IP or NaN
+# $3 - new gateway device or NaN
+# $4 - old gateway identifier or NaN
+# $5 - old gateway IP or NaN
+# $6 - old gateway device or NaN
+
+onntrack -D -p udp


### PR DESCRIPTION
When default route changing, all tcp connections resets, but udp streams remains.
It leads to udp related network services try to send packages on old, dead gateway and application not working. For example, asterisk affected to this trouble.
The solution is drop all udp streams using conntrack.
